### PR TITLE
Update how we get the hostname to support CentOS kitchen tests

### DIFF
--- a/test/integration/application/serverspec/server_spec.rb
+++ b/test/integration/application/serverspec/server_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 require 'socket'
 
 describe "Application LWRP" do
-  let(:host_name) { Socket.gethostname }
+  let(:host_name) { Socket.gethostname.split('.').first }
   let(:app_tags) { MachineTag::Set.new(JSON.parse(IO.read("/vagrant/cache_dir/machine_tag_cache/#{host_name}/tags.json"))) }
 
   it "should have 5 application specific entries" do

--- a/test/integration/database/serverspec/server_spec.rb
+++ b/test/integration/database/serverspec/server_spec.rb
@@ -4,7 +4,7 @@ require 'socket'
 require 'time'
 
 describe "Database server tags" do
-  let(:host_name) { Socket.gethostname }
+  let(:host_name) { Socket.gethostname.split('.').first }
   let(:db_tags) { MachineTag::Set.new(JSON.parse(IO.read("/vagrant/cache_dir/machine_tag_cache/#{host_name}/tags.json"))) }
 
   it "should have 5 application specific entries" do

--- a/test/integration/default/serverspec/server_spec.rb
+++ b/test/integration/default/serverspec/server_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 require 'socket'
 
 describe "Default server tags" do
-  let(:host_name) { Socket.gethostname }
+  let(:host_name) { Socket.gethostname.split('.').first }
   let(:default_tags) { MachineTag::Set.new(JSON.parse(IO.read("/vagrant/cache_dir/machine_tag_cache/#{host_name}/tags.json"))) }
 
   it "should have a UUID of 01-ABCDEFG123456" do

--- a/test/integration/load_balancer/serverspec/server_spec.rb
+++ b/test/integration/load_balancer/serverspec/server_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 require 'socket'
 
 describe "Load balancer server tags" do
-  let(:host_name) { Socket.gethostname }
+  let(:host_name) { Socket.gethostname.split('.').first }
   let(:lb_tags) { MachineTag::Set.new(JSON.parse(IO.read("/vagrant/cache_dir/machine_tag_cache/#{host_name}/tags.json"))) }
 
   it "should have 2 application specific entry" do


### PR DESCRIPTION
Hi, I made this change after noticing that Socket.gethostname for CentOS would return long hostnames such as: "load-balancer-centos-64.vagrantup.com". However, the tags.json files would reside in load-balancer-centos-64. This affects any tests, in any cookbook, that uses Socket.gethostname. I checked that this does not break Ubuntu 12.04 tests.
