### PR TITLE
pinning gems for ruby and chef 

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -2,7 +2,7 @@ site :opscode
 
 metadata
 
-cookbook 'machine_tag', github: 'rightscale-cookbooks/machine_tag', branch: 'v1.2.1'
+cookbook 'machine_tag', github: 'rightscale-cookbooks/machine_tag'
 
 group :integration do
   cookbook 'fake', path: './test/cookbooks/fake'

--- a/Gemfile
+++ b/Gemfile
@@ -11,4 +11,8 @@ group :integration do
   gem 'chefspec', '~> 3.4.0'
   gem 'rspec-expectations'
   gem 'travis-lint'
+  gem 'rack', '= 1.6.4'
+  gem 'json', '~> 1.8', '>= 1.8.3'
+  gem 'buff-ignore', '= 1.1.1'
+  gem 'net-http-persistent', '= 2.9.4'
 end

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Github Repository: [https://github.com/rightscale-cookbooks/rightscale_tag](http
 
 # Requirements
 
-* Requires Chef 11 or higher
+* Requires Chef 11
 * Requires Ruby 1.9 or higher
 * Requires [RightLink 10](http://docs.rightscale.com/rl10/) See cookbook version 1.0.6 for RightLink 6 support
 * Platform

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cookbooks@rightscale.com'
 license          'Apache 2.0'
 description      'Provides LWRPs and helper methods for building 3-tier applications using machine tags in RightScale'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '1.2.1'
+version          '1.2.2'
 
 depends 'machine_tag', '~> 1.2.1'
 depends 'marker', '~> 1.0.0'


### PR DESCRIPTION
pinning gems to fix ruby and chef compatibility.
update Berksfile to use latest release maching_tag